### PR TITLE
Fix NPE in calcScale, resolve #141

### DIFF
--- a/simplecropview/src/main/java/com/isseiaoki/simplecropview/CropImageView.java
+++ b/simplecropview/src/main/java/com/isseiaoki/simplecropview/CropImageView.java
@@ -539,8 +539,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
   }
 
   private float calcScale(int viewW, int viewH, float angle) {
-    mImgWidth = getDrawable().getIntrinsicWidth();
-    mImgHeight = getDrawable().getIntrinsicHeight();
+    if (getDrawable() != null) {
+      mImgWidth = getDrawable().getIntrinsicWidth();
+      mImgHeight = getDrawable().getIntrinsicHeight();
+    }
     if (mImgWidth <= 0) mImgWidth = viewW;
     if (mImgHeight <= 0) mImgHeight = viewH;
     float viewRatio = (float) viewW / (float) viewH;


### PR DESCRIPTION
If getDrawable() returns null, this method will use old values of mImgWidth and mImgHeight.